### PR TITLE
Fix decoding Alpha Initialization

### DIFF
--- a/qoi.lua
+++ b/qoi.lua
@@ -120,7 +120,7 @@ function qoi.decode(s)
 	local r = 0
 	local g = 0
 	local b = 0
-	local a = -1
+	local a = 255
 
 	local run = 0
 


### PR DESCRIPTION
I tried using this library and it wasn't working for me. I tracked the issue down to the alpha initialization in the decoder. 

When encoding we initialize prevA to 255. So if the first pixel has an alpha of 255, then we will add a QOI_OP_RGB op as the first op. 

When decoding this, we will get a QOI_OP_RGB for the first pixel and leave A at it's current value of -1. So a will be -1 when it should be 255 in this case.  

I am not sure if there is some context of how this was being used that makes this work that I am possibly missing. 